### PR TITLE
Handle empty tuple

### DIFF
--- a/include/nnvm/tuple.h
+++ b/include/nnvm/tuple.h
@@ -233,6 +233,15 @@ class Tuple {
         return is;
     }
     }
+    // Handle empty tuple
+    while (isspace(is.peek())) {
+      is.get();
+    }
+    if (is.peek() == ')') {
+      is.get();
+      return is;
+    }
+    // Handle non-empty tuple
     ValueType idx;
     std::vector<ValueType> tmp;
     while (is >> idx) {


### PR DESCRIPTION
The default value for many fields is empty tuple "()", like in https://github.com/dmlc/mxnet/blob/master/src/operator/convolution-inl.h#L48

This bug affects parameter parsing. https://github.com/dmlc/dmlc-core/blob/master/include/dmlc/parameter.h#L520