### PR TITLE
Add codegen field in graph node

### DIFF
--- a/include/nnvm/codegen.h
+++ b/include/nnvm/codegen.h
@@ -1,0 +1,21 @@
+#ifndef NNVM_CODEGEN_H_
+#define NNVM_CODEGEN_H_
+
+#include <memory>
+#include <vector>
+#include "./tuple.h"
+#include "./node.h"
+
+namespace nnvm {
+
+class CodeGen {
+ public:
+  virtual void FeedInputShapes(const std::vector<TShape>& shapes) = 0;
+  virtual void FeedOutputShapes(const std::vector<TShape>& shapes) = 0;
+  virtual void FeedInputTypes(const std::vector<int>& types) = 0;
+  virtual void Generate(const Node* node) = 0;
+};
+
+}  // namespace nnvm
+
+#endif  // NNVM_CODEGEN_H_

--- a/include/nnvm/node.h
+++ b/include/nnvm/node.h
@@ -17,6 +17,7 @@ namespace nnvm {
 
 // Forward declare node.
 class Node;
+class CodeGen;
 
 /*!
  * \brief we always used NodePtr for a reference pointer
@@ -91,6 +92,7 @@ struct NodeAttrs {
    * The object can be used to quickly access attributes.
    */
   any parsed;
+
 };
 
 /*!
@@ -107,6 +109,11 @@ class Node {
    *  Gives operation must be performed before this operation.
    */
   std::vector<NodePtr> control_deps;
+
+  // Can only be null if its op* is also null, which means it is a
+  // variable node.
+  std::shared_ptr<CodeGen> codegen{nullptr};
+
   /*! \brief destructor of node */
   ~Node();
   /*! \return operator in this node */

--- a/include/nnvm/op_attr_types.h
+++ b/include/nnvm/op_attr_types.h
@@ -12,6 +12,7 @@
 #include <functional>
 #include "./base.h"
 #include "./node.h"
+#include "./codegen.h"
 #include "./tuple.h"
 
 namespace nnvm {
@@ -153,6 +154,11 @@ using FSetInputVarAttrOnCompose = std::function<void(
     const NodeAttrs& attrs,
     NodePtr var,
     const int index)>;
+
+using FCodeGenCreator = std::function<std::shared_ptr<CodeGen>()>;
+
+using FBackwardCodeGenCreator = std::function<std::shared_ptr<CodeGen>(
+    const NodePtr& fwd_node)>;
 
 }  // namespace nnvm
 


### PR DESCRIPTION
Motivation Issue
------------------
During autograd, we first generate forward path by concrete execution. We then call `GradientPass` to generate backward graph. We then **prune out** the forward graph since it has already been executed and no resources should be allocated as well. However, this approach fails in https://github.com/dmlc/mxnet/blob/master/src/executor/attach_op_execs_pass.cc#L202 . This is because converting BackwardOpExecutor relies on forward node, which has already been deleted.

There are two ways to view this problem:
* We should not remove the forward nodes, since some of their states should be preserved (i.e, it's the pass developer's fault).
* Generating executors (codes) for one node should not rely on other nodes, since they may be deleted (i.e, it's the mxnet backend developer's fault).

I think both views are somewhat correct, and the problem is there is **no clear semantics** on what is a valid IR (dataflow graph) that can be accepted. If take LLVM as analogy, LLVM pass does not allow to generate IR that is invalid (based on its definition). Here in NNVM, this part is missing.

Defining Semantics of NNVM IR
------------------------------------
The reason is because the node is basically a black box. However, we can still define some high-level semantics of the node. Therefore, I suggest to add a `CodeGen` field in the `Node` structure meaning that **the node is able to convert to some codes for the backend**.

A dataflow graph (NNVM IR) is valid *if and only if* all the nodes in the graph has defined code generator. The code generator has following interface:
```c++
class CodeGen {
 public:
  virtual void FeedInputShapes(const std::vector<TShape>& shapes) = 0;
  virtual void FeedOutputShapes(const std::vector<TShape>& shapes) = 0;
  virtual void FeedInputTypes(const std::vector<int>& types) = 0;
  virtual void Generate(const Node* node) = 0;
};
```
Here, it relies *only* on the current node to generate code (or OpExecutor in MXNet's backend). Each pass must generate valid IR. Otherwise, error is raised.

How this decouples forward & backward operators
--------------------------------------------------
Based on the above definition, now it is the `GradientPass` 's responsibility to generate valid IR so that each node has valid CodeGen. The backward node's CodeGen is created in this pass by storing the `NodePtr` directly to the CodeGen object. This allows succeeding passes to remove any nodes since the required states have been stored. Two op attributes are added to support this:
```c++
using FCodeGenCreator = std::function<std::shared_ptr<CodeGen>()>;

using FBackwardCodeGenCreator = std::function<std::shared_ptr<CodeGen>(
    const NodePtr& fwd_node)>;
```
I have implemented the mechanism in my repo [here](https://github.com/jermainewang/mxnet/blob/master/src/nnvm/legacy_op_util.cc#L524). This also greatly simplified the `attach_op_exec_pass` (i.e, the code gen part in MXNet backend). The demo code is [here](https://github.com/jermainewang/mxnet/blob/master/src/executor/attach_op_execs_pass.cc#L63). You can see creating `OpExecutor` for backward node no longer depends on forward node.

Q: *We already have `Op` pointer. Why another `CodeGen` field?*
A: The `Op*` field is a static attribute of the node. For example, two conv nodes will share the `Op*` while they may have different code gen.

If you guys think this is a necessary change. I will keep working on this including:
* Replace the `NDArrayFunction` with `CodeGen`.
* Replace the `FCompute` with `CodeGen`.
So everything will become `CodeGen`.

@tqchen @piiswrong @ZihengJiang 