### PR TITLE
Fixed make no_optimization runs indefinitely when run the memcost example provided 

### DIFF
--- a/src/pass/plan_memory.cc
+++ b/src/pass/plan_memory.cc
@@ -323,6 +323,10 @@ Graph PlanMemory(Graph ret) {
       ret.attrs["storage_num_not_allocated"] = std::make_shared<any>(storage_num_not_allocated);
       min_allocated_bytes = storage_allocated_bytes;
     }
+
+    if (max_match_range == 0){
+      break;
+    }
   }
   return ret;
 }

--- a/src/pass/plan_memory.cc
+++ b/src/pass/plan_memory.cc
@@ -324,7 +324,7 @@ Graph PlanMemory(Graph ret) {
       min_allocated_bytes = storage_allocated_bytes;
     }
 
-    if (max_match_range == 0){
+    if (max_match_range == 0) {
       break;
     }
   }


### PR DESCRIPTION
Fixed make no_optimization runs indefinitely when run the memcost example provided

Run the memcost example provided [here](https://github.com/dmlc/mxnet/tree/master/example/memcost).

    make with_inplace, make with_sharing and make with_both all three use the same amount of Memory Total 1340 MB allocated.

    make no_optimization runs indefinitely
Environment info

MXNet versions tested:

    0.10.1
    build from source / master

Operating System: Linux
 