### PR TITLE
Fix error during loading library in python3

### DIFF
--- a/python/nnvm/cython/base.pyi
+++ b/python/nnvm/cython/base.pyi
@@ -80,7 +80,7 @@ cdef BuildDoc(nn_uint num_args,
         type_info = arg_types[i]
         ret = '%s : %s' % (key, type_info)
         if len(arg_descs[i]) != 0:
-            ret += '\n    ' + arg_descs[i]
+            ret += '\n    ' + py_str(arg_descs[i])
         param_str.append(ret)
     doc_str = ('Parameters\n' +
                '----------\n' +


### PR DESCRIPTION
I'm trying to load mxnet library from nnvm python interface in python3, and got an error in function BuildDoc. Solution copied from mxnet/python/mxnet/symbol.py
