### PR TITLE
remove unused variable

### DIFF
--- a/src/core/symbolic.cc
+++ b/src/core/symbolic.cc
@@ -436,7 +436,6 @@ Symbol Symbol::GetInternals() const {
 }
 
 Symbol Symbol::GetChildren() const {
-  static auto& fnum_vis_output = Op::GetAttr<FNumVisibleOutputs>("FNumVisibleOutputs");
   Symbol ret;
   std::unordered_set<Node*> visited;
   for (const auto& p : this->outputs) {


### PR DESCRIPTION
To help remove compilation warnings