### PR TITLE
Address execution hot spots

### DIFF
--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -16,6 +16,7 @@ int NNListAllOpNames(nn_uint *out_size,
   NNAPIThreadLocalEntry *ret = NNAPIThreadLocalStore::Get();
   ret->ret_vec_str = dmlc::Registry<Op>::ListAllNames();
   ret->ret_vec_charp.clear();
+  ret->ret_vec_charp.reserve(ret->ret_vec_str.size());
   for (size_t i = 0; i < ret->ret_vec_str.size(); ++i) {
     ret->ret_vec_charp.push_back(ret->ret_vec_str[i].c_str());
   }
@@ -65,6 +66,7 @@ int NNGetOpInfo(OpHandle handle,
   *num_doc_args = static_cast<nn_uint>(op->arguments.size());
   if (return_type) *return_type = nullptr;
   ret->ret_vec_charp.clear();
+  ret->ret_vec_charp.reserve(op->arguments.size() * 3);
   for (size_t i = 0; i < op->arguments.size(); ++i) {
     ret->ret_vec_charp.push_back(op->arguments[i].name.c_str());
   }
@@ -214,6 +216,7 @@ int NNSymbolListAttrs(SymbolHandle symbol,
   }
   *out_size = attr.size();
   ret->ret_vec_charp.clear();
+  ret->ret_vec_charp.reserve(ret->ret_vec_str.size());
   for (size_t i = 0; i < ret->ret_vec_str.size(); ++i) {
     ret->ret_vec_charp.push_back(ret->ret_vec_str[i].c_str());
   }
@@ -230,6 +233,7 @@ int NNSymbolListInputVariables(SymbolHandle symbol,
   API_BEGIN();
   std::vector<NodePtr> vs = s->ListInputs(Symbol::ListInputOption(option));
   ret->ret_handles.clear();
+  ret->ret_handles.reserve(vs.size());
   for (size_t i = 0; i < vs.size(); ++i) {
     nnvm::Symbol* rs = new nnvm::Symbol();
     rs->outputs.push_back(NodeEntry{vs[i], 0, 0});
@@ -250,6 +254,7 @@ int NNSymbolListInputNames(SymbolHandle symbol,
   ret->ret_vec_str =
       s->ListInputNames(Symbol::ListInputOption(option));
   ret->ret_vec_charp.clear();
+  ret->ret_vec_charp.reserve(ret->ret_vec_str.size());
   for (size_t i = 0; i < ret->ret_vec_str.size(); ++i) {
     ret->ret_vec_charp.push_back(ret->ret_vec_str[i].c_str());
   }
@@ -266,6 +271,7 @@ int NNSymbolListOutputNames(SymbolHandle symbol,
   API_BEGIN();
   ret->ret_vec_str = s->ListOutputNames();
   ret->ret_vec_charp.clear();
+  ret->ret_vec_charp.reserve(ret->ret_vec_str.size());
   for (size_t i = 0; i < ret->ret_vec_str.size(); ++i) {
     ret->ret_vec_charp.push_back(ret->ret_vec_str[i].c_str());
   }

--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -15,7 +15,7 @@ int NNListAllOpNames(nn_uint *out_size,
   API_BEGIN();
   NNAPIThreadLocalEntry *ret = NNAPIThreadLocalStore::Get();
   ret->ret_vec_str = dmlc::Registry<Op>::ListAllNames();
-  ret->ret_vec_charp.clear();
+  ret->ret_vec_charp.resize(0);
   ret->ret_vec_charp.reserve(ret->ret_vec_str.size());
   for (size_t i = 0; i < ret->ret_vec_str.size(); ++i) {
     ret->ret_vec_charp.push_back(ret->ret_vec_str[i].c_str());
@@ -65,7 +65,7 @@ int NNGetOpInfo(OpHandle handle,
   *description = op->description.c_str();
   *num_doc_args = static_cast<nn_uint>(op->arguments.size());
   if (return_type) *return_type = nullptr;
-  ret->ret_vec_charp.clear();
+  ret->ret_vec_charp.resize(0);
   ret->ret_vec_charp.reserve(op->arguments.size() * 3);
   for (size_t i = 0; i < op->arguments.size(); ++i) {
     ret->ret_vec_charp.push_back(op->arguments[i].name.c_str());
@@ -209,7 +209,8 @@ int NNSymbolListAttrs(SymbolHandle symbol,
       s->ListAttrs(static_cast<Symbol::ListAttrOption>(option));  // NOLINT(*)
 
   std::vector<std::string>& attr_list = ret->ret_vec_str;
-  attr_list.clear();
+  attr_list.resize(0);
+  attr_list.reserve(attr.size());
   for (const auto& kv : attr) {
     attr_list.push_back(kv.first);
     attr_list.push_back(kv.second);
@@ -232,7 +233,7 @@ int NNSymbolListInputVariables(SymbolHandle symbol,
   NNAPIThreadLocalEntry *ret = NNAPIThreadLocalStore::Get();
   API_BEGIN();
   std::vector<NodePtr> vs = s->ListInputs(Symbol::ListInputOption(option));
-  ret->ret_handles.clear();
+  ret->ret_handles.resize(0);
   ret->ret_handles.reserve(vs.size());
   for (size_t i = 0; i < vs.size(); ++i) {
     nnvm::Symbol* rs = new nnvm::Symbol();
@@ -253,7 +254,7 @@ int NNSymbolListInputNames(SymbolHandle symbol,
   API_BEGIN();
   ret->ret_vec_str =
       s->ListInputNames(Symbol::ListInputOption(option));
-  ret->ret_vec_charp.clear();
+  ret->ret_vec_charp.resize(0);
   ret->ret_vec_charp.reserve(ret->ret_vec_str.size());
   for (size_t i = 0; i < ret->ret_vec_str.size(); ++i) {
     ret->ret_vec_charp.push_back(ret->ret_vec_str[i].c_str());
@@ -270,7 +271,7 @@ int NNSymbolListOutputNames(SymbolHandle symbol,
   NNAPIThreadLocalEntry *ret = NNAPIThreadLocalStore::Get();
   API_BEGIN();
   ret->ret_vec_str = s->ListOutputNames();
-  ret->ret_vec_charp.clear();
+  ret->ret_vec_charp.resize(0);
   ret->ret_vec_charp.reserve(ret->ret_vec_str.size());
   for (size_t i = 0; i < ret->ret_vec_str.size(); ++i) {
     ret->ret_vec_charp.push_back(ret->ret_vec_str[i].c_str());

--- a/src/core/symbolic.cc
+++ b/src/core/symbolic.cc
@@ -207,6 +207,7 @@ std::vector<NodePtr> Symbol::ListInputs(ListInputOption option) const {
           }
         }
       });
+    ret.reserve(vlist.size());
     for (const NodePtr& node : vlist) {
       if ((option == kReadOnlyArgs && mutable_set.count(node.get()) == 0) ||
           (option == kAuxiliaryStates && mutable_set.count(node.get()) != 0)) {
@@ -230,6 +231,7 @@ std::vector<std::string> Symbol::ListOutputNames() const {
   static auto& flist_ouputs = Op::GetAttr<FListOutputNames>("FListOutputNames");
 
   std::vector<std::string> ret;
+  ret.reserve(outputs.size());
   for (auto &head : outputs) {
     if (head.node->is_variable()) {
       ret.push_back(head.node->attrs.name);


### PR DESCRIPTION
resize+copy when adding items to these vectors are witnessed performance problems.  reserve() pre-allocates memory for the results.