### PR TITLE
Fix Cmake error on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,12 @@ endif()
 
 # ---[ Install lib, header and docs
 if(BUILD_SHARED_NNVM)
-  install(TARGETS nnvm LIBRARY DESTINATION lib)
+  if(WIN32)
+    install(TARGETS nnvm RUNTIME DESTINATION bin)
+    install(TARGETS nnvm ARCHIVE DESTINATION lib)
+  else()
+    install(TARGETS nnvm LIBRARY DESTINATION lib)
+  endif()
 endif()
 if(BUILD_STATIC_NNVM)
   install(TARGETS nnvm_static ARCHIVE DESTINATION lib)


### PR DESCRIPTION
With CMake 3.7.2 building on Windows 10 for VS 2015, the following error occurred:

```
CMake Error at CMakeLists.txt:90 (install):
  install Library TARGETS given no DESTINATION!
```

Quote from [CMake documentation](https://cmake.org/cmake/help/v3.10/command/install.html):

>For non-DLL platforms shared libraries are treated as LIBRARY targets, except that those marked with the FRAMEWORK property are treated as FRAMEWORK targets on OS X. **For DLL platforms the DLL part of a shared library is treated as a RUNTIME target and the corresponding import library is treated as an ARCHIVE target. All Windows-based systems including Cygwin are DLL platforms.**

(Removed trailing spaces nearby)