### PR TITLE
API call to get symbol output count

### DIFF
--- a/include/nnvm/c_api.h
+++ b/include/nnvm/c_api.h
@@ -247,6 +247,17 @@ NNVM_DLL int NNSymbolListInputNames(SymbolHandle symbol,
 NNVM_DLL int NNSymbolListOutputNames(SymbolHandle symbol,
                                      nn_uint *out_size,
                                      const char ***out_str_array);
+
+
+/*!
+ * \brief Supply number of outputs of the symbol.
+ * \param symbol the symbol
+ * \param output_count number of outputs
+ * \return 0 when success, -1 when failure happens
+ */
+NNVM_DLL int NNSymbolGetOutputCount(SymbolHandle symbol,
+                                    nn_uint *output_count);
+
 /*!
  * \brief Get a symbol that contains all the internals.
  * \param symbol The symbol

--- a/include/nnvm/c_api.h
+++ b/include/nnvm/c_api.h
@@ -255,7 +255,7 @@ NNVM_DLL int NNSymbolListOutputNames(SymbolHandle symbol,
  * \param output_count number of outputs
  * \return 0 when success, -1 when failure happens
  */
-NNVM_DLL int NNSymbolGetOutputCount(SymbolHandle symbol,
+NNVM_DLL int NNSymbolGetNumOutputs(SymbolHandle symbol,
                                     nn_uint *output_count);
 
 /*!

--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -281,6 +281,14 @@ int NNSymbolListOutputNames(SymbolHandle symbol,
   API_END();
 }
 
+int NNSymbolGetOutputCount(SymbolHandle symbol,
+                           nn_uint *output_count) {
+  Symbol *s = static_cast<Symbol*>(symbol);
+  API_BEGIN();
+    *output_count = static_cast<nn_uint>(s->outputs.size());
+  API_END();
+}
+
 int NNSymbolCompose(SymbolHandle sym,
                     const char *name,
                     nn_uint num_args,

--- a/src/c_api/c_api_symbolic.cc
+++ b/src/c_api/c_api_symbolic.cc
@@ -281,7 +281,7 @@ int NNSymbolListOutputNames(SymbolHandle symbol,
   API_END();
 }
 
-int NNSymbolGetOutputCount(SymbolHandle symbol,
+int NNSymbolGetNumOutputs(SymbolHandle symbol,
                            nn_uint *output_count) {
   Symbol *s = static_cast<Symbol*>(symbol);
   API_BEGIN();


### PR DESCRIPTION
MXNet Symbol.__getitem__ using list_outputs() is too expensive, when it only cares about the output count in most cases. 

Dependency of: https://github.com/apache/incubator-mxnet/pull/8989

Showing up as a hot spot:


![list_outputs_profiling](https://user-images.githubusercontent.com/11234557/33741690-367cc91e-db5a-11e7-8c84-c6e13e3b3d81.png)
