### PR TITLE
Add missing cmath header

### DIFF
--- a/src/top/tensor/elemwise.cc
+++ b/src/top/tensor/elemwise.cc
@@ -7,6 +7,7 @@
 #include <nnvm/node.h>
 #include <nnvm/op_attr_types.h>
 #include <nnvm/top/tensor.h>
+#include <cmath>
 #include "../op_common.h"
 #include "../elemwise_op_common.h"
 


### PR DESCRIPTION
f9ed337552a26cc55c7c0fb22cd54839ee13f19c added a call to std::log
without including cmath