### PR TITLE
Make choice of archiver configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ build/src/%.o: src/%.cc
 
 lib/libnnvm.a: $(ALL_DEP)
 	@mkdir -p $(@D)
-	ar crv $@ $(filter %.o, $?)
+	$(AR) crv $@ $(filter %.o, $?)
 
 lib/libnnvm_compiler.$(SHARED_LIBRARY_SUFFIX): lib/libnnvm.a ${TOP_OBJ}
 	@mkdir -p $(@D)

--- a/make/config.mk
+++ b/make/config.mk
@@ -22,6 +22,9 @@
 
 export NVCC = nvcc
 
+# choice of archiver
+export AR = ar
+
 # the additional link flags you want to add
 ADD_LDFLAGS=
 


### PR DESCRIPTION
At present, the build system assumes that the Unix archiv utility 'ar'
will always be present in PATH, but this might not be true if a separate
toolchain is being used. This patch makes the build system a bit more
cross-compile capable.