### PR TITLE
Add support for keras upsampling

### DIFF
--- a/python/nnvm/frontend/keras.py
+++ b/python/nnvm/frontend/keras.py
@@ -274,21 +274,21 @@ def _convert_upsample(insym, keras_layer, _):
 
     if upsample_type == "UpSampling1D":
         h = keras_layer.size
-        params = {'scale': [h]}
+        params = {'scale': h}
     elif upsample_type == "UpSampling2D":
         h, w = keras_layer.size
         if h != w:
             raise TypeError("Unsupported upsampling type with different axes size : {}"
-                            .format(keras_layer))
+                            .format(keras_layer.size))
         params = {'scale': h}
     elif upsample_type == "UpSampling3D":
         h, w, d = keras_layer.size
         if h != w or w != d:
             raise TypeError("Unsupported upsampling type with different axes size : {}"
-                            .format(keras_layer))
+                            .format(keras_layer.size))
         params = {'scale': h}
     else:
-        raise TypeError("Unsupported upsampling type : {}".format(keras_layer))
+        raise TypeError("Unsupported upsampling type : {}".format(upsample_type))
 
     return _sym.upsampling(insym, **params)
 
@@ -383,6 +383,7 @@ _convert_map = {
     'Subtract'                 : _convert_merge,
     'Multiply'                 : _convert_merge,
     'ZeroPadding2D'            : _convert_padding,
+    'UpSampling2D'           : _convert_upsample,
 
     # 'ZeroPadding1D'          : _convert_padding,
     # 'AveragePooling1D'       : _convert_pooling,
@@ -392,7 +393,6 @@ _convert_map = {
     # 'Cropping1D'             : _convert_cropping,
     # 'Cropping2D'             : _convert_cropping,
     # 'UpSampling1D'           : _convert_upsample,
-    'UpSampling2D'           : _convert_upsample,
     # 'UpSampling3D'           : _convert_upsample,
     # 'Conv1D'                 : _convert_convolution1d,
 

--- a/python/nnvm/frontend/keras.py
+++ b/python/nnvm/frontend/keras.py
@@ -268,6 +268,29 @@ def _convert_pooling(insym, keras_layer, symtab):
             raise TypeError("Unsupported pooling type : {}".format(keras_layer))
 
 
+def _convert_upsample(insym, keras_layer, symtab):
+    _check_data_format(keras_layer)
+    upsample_type = type(keras_layer).__name__
+
+    if upsample_type == "UpSampling1D":
+        h = keras_layer.size
+        params = {'scale': [h]}
+    elif upsample_type == "UpSampling2D":
+        h, w = keras_layer.size
+        if h != w:
+            raise TypeError("Unsupported upsampling type with different dimensions : {}".format(keras_layer))
+        params = {'scale': h}
+    elif upsample_type == "UpSampling3D":
+        h, w, d = keras_layer.size
+        if h != w or w != d:
+            raise TypeError("Unsupported upsampling type with different dimensions : {}".format(keras_layer))
+        params = {'scale': h}
+    else:
+            raise TypeError("Unsupported upsampling type : {}".format(keras_layer))
+
+    return _sym.upsampling(insym, **params)
+
+
 def _convert_batchnorm(insym, keras_layer, symtab):
     params = {'scale': False,
               'center': False,
@@ -366,8 +389,9 @@ _convert_map = {
     # 'GlobalMaxPooling1D'     : _convert_pooling,
     # 'Cropping1D'             : _convert_cropping,
     # 'Cropping2D'             : _convert_cropping,
-    # 'UpSampling1D'           : _convert_upsample,
-    # 'UpSampling2D'           : _convert_upsample,
+    'UpSampling1D'           : _convert_upsample,
+    'UpSampling2D'           : _convert_upsample,
+    'UpSampling3D'           : _convert_upsample,
     # 'Conv1D'                 : _convert_convolution1d,
 
     # 'GRU'                    : _convert_gru,

--- a/python/nnvm/frontend/keras.py
+++ b/python/nnvm/frontend/keras.py
@@ -278,12 +278,14 @@ def _convert_upsample(insym, keras_layer, symtab):
     elif upsample_type == "UpSampling2D":
         h, w = keras_layer.size
         if h != w:
-            raise TypeError("Unsupported upsampling type with different dimensions : {}".format(keras_layer))
+            raise TypeError("Unsupported upsampling type with different axes size : {}"
+                .format(keras_layer))
         params = {'scale': h}
     elif upsample_type == "UpSampling3D":
         h, w, d = keras_layer.size
         if h != w or w != d:
-            raise TypeError("Unsupported upsampling type with different dimensions : {}".format(keras_layer))
+            raise TypeError("Unsupported upsampling type with different axes size : {}"
+                .format(keras_layer))
         params = {'scale': h}
     else:
             raise TypeError("Unsupported upsampling type : {}".format(keras_layer))

--- a/python/nnvm/frontend/keras.py
+++ b/python/nnvm/frontend/keras.py
@@ -279,13 +279,13 @@ def _convert_upsample(insym, keras_layer, symtab):
         h, w = keras_layer.size
         if h != w:
             raise TypeError("Unsupported upsampling type with different axes size : {}"
-                .format(keras_layer))
+                            .format(keras_layer))
         params = {'scale': h}
     elif upsample_type == "UpSampling3D":
         h, w, d = keras_layer.size
         if h != w or w != d:
             raise TypeError("Unsupported upsampling type with different axes size : {}"
-                .format(keras_layer))
+                            .format(keras_layer))
         params = {'scale': h}
     else:
             raise TypeError("Unsupported upsampling type : {}".format(keras_layer))

--- a/python/nnvm/frontend/keras.py
+++ b/python/nnvm/frontend/keras.py
@@ -268,7 +268,7 @@ def _convert_pooling(insym, keras_layer, symtab):
             raise TypeError("Unsupported pooling type : {}".format(keras_layer))
 
 
-def _convert_upsample(insym, keras_layer, symtab):
+def _convert_upsample(insym, keras_layer, _):
     _check_data_format(keras_layer)
     upsample_type = type(keras_layer).__name__
 

--- a/python/nnvm/frontend/keras.py
+++ b/python/nnvm/frontend/keras.py
@@ -288,7 +288,7 @@ def _convert_upsample(insym, keras_layer, symtab):
                             .format(keras_layer))
         params = {'scale': h}
     else:
-            raise TypeError("Unsupported upsampling type : {}".format(keras_layer))
+        raise TypeError("Unsupported upsampling type : {}".format(keras_layer))
 
     return _sym.upsampling(insym, **params)
 

--- a/python/nnvm/frontend/keras.py
+++ b/python/nnvm/frontend/keras.py
@@ -391,9 +391,9 @@ _convert_map = {
     # 'GlobalMaxPooling1D'     : _convert_pooling,
     # 'Cropping1D'             : _convert_cropping,
     # 'Cropping2D'             : _convert_cropping,
-    'UpSampling1D'           : _convert_upsample,
+    # 'UpSampling1D'           : _convert_upsample,
     'UpSampling2D'           : _convert_upsample,
-    'UpSampling3D'           : _convert_upsample,
+    # 'UpSampling3D'           : _convert_upsample,
     # 'Conv1D'                 : _convert_convolution1d,
 
     # 'GRU'                    : _convert_gru,


### PR DESCRIPTION
Map keras 'UpSampling*D' operators to topi upsampling. AFAICT, topi only supports symmetric upsampling, where all dimensions are equal - this PR will raise an error if this condition does not hold true. (Please correct me if I am wrong!)

Fixes issue #304 