### PR TITLE
Add more Keras tests

### DIFF
--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -128,11 +128,11 @@ def test_forward_conv_odd_small():
 
 def test_forward_conv_even_strided():
     print("test_forward_conv_even_strided")
-    data = keras.layers.Input(shape=(32,32,4))
-    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), strides=(2, 1), padding='same')(data)
-    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), strides=(1, 2), padding='same')(x)
-    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), strides=(1, 2), padding='valid')(x)
-    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), strides=(2, 1), padding='valid')(x)
+    data = keras.layers.Input(shape=(64,64,4))
+    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), strides=(2, 2), padding='same')(data)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), strides=(2, 2), padding='same')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), strides=(2, 2), padding='valid')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), strides=(2, 2), padding='valid')(x)
     print(keras.models.Model(data, x).output_shape)
     x = keras.layers.GlobalMaxPooling2D()(x)
     keras_model = keras.models.Model(data, x)
@@ -141,11 +141,11 @@ def test_forward_conv_even_strided():
 
 def test_forward_conv_odd_strided():
     print("test_forward_conv_odd_strided")
-    data = keras.layers.Input(shape=(31,31,4))
-    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), strides=(1, 2), padding='same')(data)
-    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), strides=(2, 1), padding='same')(x)
-    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), strides=(1, 2), padding='valid')(x)
-    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), strides=(2, 1), padding='valid')(x)
+    data = keras.layers.Input(shape=(65,65,4))
+    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), strides=(2, 2), padding='same')(data)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), strides=(2, 2), padding='same')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), strides=(2, 2), padding='valid')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), strides=(2, 2), padding='valid')(x)
     print(keras.models.Model(data, x).output_shape)
     x = keras.layers.GlobalMaxPooling2D()(x)
     keras_model = keras.models.Model(data, x)

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -264,6 +264,15 @@ def test_forward_unet():
     verify_keras_frontend(keras_model)
 
 
+def test_forward_vgg16_layer():
+    print("test_forward_vgg16_layer")
+    keras_model = keras.applications.vgg16.VGG16(include_top=True, weights=None,
+        input_shape=(224,224,3), classes=1000)
+    data = keras.layers.Input((224,224,3))
+    keras_model = keras.models.Model(data, keras_model(data))
+    verify_keras_frontend(keras_model)
+
+
 if __name__ == '__main__':
     test_forward_softrelu()
     test_forward_leaky_relu()
@@ -282,6 +291,7 @@ if __name__ == '__main__':
     test_forward_xception()
     test_forward_resnet50()
     test_forward_unet()
+    test_forward_vgg16_layer()
 
     test_forward_shape_inference()
 

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -192,6 +192,7 @@ def test_forward_shape_inference():
     x = keras.layers.AveragePooling2D()(x)
     x = keras.layers.UpSampling2D()(x)
     x = keras.layers.Conv2D(filters=3, kernel_size=(3, 3), padding='same')(data)
+    x = keras.layers.GlobalAveragePooling2D(x)
     keras_model = keras.models.Model(data, x)
     verify_keras_frontend(keras_model)
 
@@ -200,7 +201,6 @@ def test_forward_vgg16():
     print("test_forward_vgg16")
     keras_model = keras.applications.vgg16.VGG16(include_top=True, weights=None,
         input_shape=(224,224,3), classes=1000)
-    keras_model.summary()
     verify_keras_frontend(keras_model)
 
 
@@ -208,7 +208,6 @@ def test_forward_xception():
     print("test_forward_xception")
     keras_model = keras.applications.xception.Xception(include_top=True, weights=None,
         input_shape=(299,299,3), classes=1000)
-    keras_model.summary()
     verify_keras_frontend(keras_model)
 
 
@@ -216,7 +215,6 @@ def test_forward_resnet50():
     print("test_forward_resnet50")
     keras_model = keras.applications.resnet50.ResNet50(include_top=True, weights=None,
         input_shape=(224,224,3), classes=1000)
-    keras_model.summary()
     verify_keras_frontend(keras_model)
 
 
@@ -224,9 +222,9 @@ if __name__ == '__main__':
     test_forward_softrelu()
     test_forward_leaky_relu()
     test_forward_dense()
-    # test_forward_conv_small()
-    # test_forward_conv()
-    # test_forward_transpose_conv()
+    test_forward_conv_small()
+    test_forward_conv()
+    test_forward_transpose_conv()
     test_forward_depthwise_conv()
     test_forward_separable_conv()
     test_forward_upsample()

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -40,6 +40,7 @@ def verify_keras_frontend(keras_model):
 
 
 def test_forward_softrelu():
+    print("test_forward_softrelu")
     data = keras.layers.Input(shape=(32,32,3))
     x = keras.layers.Activation('softplus')(data)
     x = keras.layers.Concatenate()([x, x])
@@ -49,6 +50,7 @@ def test_forward_softrelu():
 
 
 def test_forward_leaky_relu():
+    print("test_forward_leaky_relu")
     data = keras.layers.Input(shape=(32,32,3))
     x = keras.layers.LeakyReLU(alpha=0.3)(data)
     x = keras.layers.Add()([x, x])
@@ -58,6 +60,7 @@ def test_forward_leaky_relu():
 
 
 def test_forward_dense():
+    print("test_forward_dense")
     data = keras.layers.Input(shape=(32,32,3))
     x = keras.layers.MaxPooling2D(pool_size=(2,2))(data)
     x = keras.layers.Flatten()(x)
@@ -66,17 +69,108 @@ def test_forward_dense():
     verify_keras_frontend(keras_model)
 
 
+def test_forward_conv_even():
+    print("test_forward_conv_even")
+    data = keras.layers.Input(shape=(32,32,4))
+    x = keras.layers.Conv2D(filters=10, kernel_size=(1,1), padding='same')(data)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(1,2), padding='same')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(2,3), padding='same')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(4,5), padding='same')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(5,6), padding='same')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(1,1), padding='valid')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(1,2), padding='valid')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(2,3), padding='valid')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), padding='valid')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(5,5), padding='valid')(x)
+    x = keras.layers.GlobalMaxPooling2D()(x)
+    keras_model = keras.models.Model(data, x)
+    verify_keras_frontend(keras_model)
+
+
+def test_forward_conv_odd():
+    print("test_forward_conv_odd")
+    data = keras.layers.Input(shape=(31,31,4))
+    x = keras.layers.Conv2D(filters=10, kernel_size=(1,1), padding='same')(data)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(1,2), padding='same')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(2,3), padding='same')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(3,4), padding='same')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(5,6), padding='same')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(1,1), padding='valid')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(1,2), padding='valid')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(2,3), padding='valid')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), padding='valid')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(5,5), padding='valid')(x)
+    x = keras.layers.GlobalMaxPooling2D()(x)
+    keras_model = keras.models.Model(data, x)
+    verify_keras_frontend(keras_model)
+
+
+def test_forward_conv_even_small():
+    print("test_forward_conv_even_small")
+    data = keras.layers.Input(shape=(4,4,4))
+    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), padding='same')(data)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), padding='same')(x)
+    x = keras.layers.GlobalMaxPooling2D()(x)
+    keras_model = keras.models.Model(data, x)
+    verify_keras_frontend(keras_model)
+
+
+def test_forward_conv_odd_small():
+    print("test_forward_conv_odd_small")
+    data = keras.layers.Input(shape=(5,5,4))
+    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), padding='same')(data)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), padding='same')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(5,5), padding='same')(x)
+    x = keras.layers.GlobalMaxPooling2D()(x)
+    keras_model = keras.models.Model(data, x)
+    verify_keras_frontend(keras_model)
+
+
+def test_forward_conv_even_strided():
+    print("test_forward_conv_even_strided")
+    data = keras.layers.Input(shape=(32,32,4))
+    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), strides=(2, 1), padding='same')(data)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), strides=(1, 2), padding='same')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), strides=(1, 2), padding='valid')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), strides=(2, 1), padding='valid')(x)
+    print(keras.models.Model(data, x).output_shape)
+    x = keras.layers.GlobalMaxPooling2D()(x)
+    keras_model = keras.models.Model(data, x)
+    verify_keras_frontend(keras_model)
+
+
+def test_forward_conv_odd_strided():
+    print("test_forward_conv_odd_strided")
+    data = keras.layers.Input(shape=(31,31,4))
+    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), strides=(1, 2), padding='same')(data)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), strides=(2, 1), padding='same')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), strides=(1, 2), padding='valid')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(4,4), strides=(2, 1), padding='valid')(x)
+    print(keras.models.Model(data, x).output_shape)
+    x = keras.layers.GlobalMaxPooling2D()(x)
+    keras_model = keras.models.Model(data, x)
+    verify_keras_frontend(keras_model)
+
+
 def test_forward_transpose_conv():
-    data = keras.layers.Input(shape=(32,32,3))
+    print("test_forward_transpose_conv")
+    data = keras.layers.Input(shape=(32,32,4))
+    x = data
     x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), strides=(2,2), padding='same')(data)
+    x = keras.layers.Conv2DTranspose(filters=10, kernel_size=(3,3), strides=(2, 2), padding='same')(x)
+    x = keras.layers.Conv2D(filters=10, kernel_size=(3,3), strides=(2,2), padding='valid')(data)
+    x = keras.layers.Conv2DTranspose(filters=10, kernel_size=(3,3), strides=(2, 2), padding='valid')(x)
     x = keras.applications.mobilenet.DepthwiseConv2D(kernel_size=(3,3), padding='same')(x)
     x = keras.layers.Conv2DTranspose(filters=64, kernel_size=(3,3), padding='valid')(x)
+    x = keras.layers.Conv2DTranspose(filters=64, kernel_size=(3,3), strides=(2, 2), padding='valid')(x)
+    x = keras.layers.Conv2DTranspose(filters=64, kernel_size=(3,3), strides=(2, 2), padding='same')(x)
     x = keras.layers.GlobalMaxPooling2D()(x)
     keras_model = keras.models.Model(data, x)
     verify_keras_frontend(keras_model)
 
 
 def test_forward_separable_conv():
+    print("test_forward_separable_conv")
     data = keras.layers.Input(shape=(32,32,3))
     x = keras.layers.SeparableConv2D(filters=10, kernel_size=(3,3),
         padding='same', activation='relu')(data)
@@ -88,6 +182,7 @@ def test_forward_separable_conv():
 
 
 def test_forward_upsample():
+    print("test_forward_upsample")
     data = keras.layers.Input(shape=(32,32,3))
     x = keras.layers.UpSampling2D(size=(3,3))(data)
     x = keras.layers.GlobalAveragePooling2D()(x)
@@ -96,18 +191,21 @@ def test_forward_upsample():
 
 
 def test_forward_vgg16():
+    print("test_forward_vgg16")
     keras_model = keras.applications.vgg16.VGG16(include_top=True, weights=None,
         input_shape=(224,224,3), classes=1000)
     verify_keras_frontend(keras_model)
 
 
 def test_forward_xception():
+    print("test_forward_xception")
     keras_model = keras.applications.xception.Xception(include_top=True, weights=None,
         input_shape=(299,299,3), classes=1000)
     verify_keras_frontend(keras_model)
 
 
 def test_forward_resnet50():
+    print("test_forward_resnet50")
     keras_model = keras.applications.resnet50.ResNet50(include_top=True, weights=None,
         input_shape=(224,224,3), classes=1000)
     verify_keras_frontend(keras_model)
@@ -117,6 +215,12 @@ if __name__ == '__main__':
     test_forward_softrelu()
     test_forward_leaky_relu()
     test_forward_dense()
+    test_forward_conv_even()
+    test_forward_conv_odd()
+    test_forward_conv_even_small()
+    test_forward_conv_odd_small()
+    test_forward_conv_even_strided()
+    test_forward_conv_odd_strided()
     test_forward_transpose_conv()
     test_forward_separable_conv()
     test_forward_upsample()

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -218,6 +218,23 @@ def test_forward_resnet50():
     verify_keras_frontend(keras_model)
 
 
+def test_forward_unet():
+    print("test_forward_unet")
+    skip = []
+    x = data = keras.layers.Input(shape=(256, 256, 3))
+    for i in range(4):
+        x = keras.layers.Conv2D(filters=8*(2**i), kernel_size=(3, 3), padding='same', activation='relu')(x)
+        x = keras.layers.MaxPooling2D()(x)
+        skip.append(x)
+    for i in range(3, -1, -1):
+        x = keras.layers.concatenate([x, skip.pop()], axis=-1)
+        x = keras.layers.Conv2D(filters=8*(2**i), kernel_size=(3, 3), padding='same', activation='relu')(x)
+        x = keras.layers.UpSampling2D()(x)
+    x = keras.layers.Conv2D(filters=1, kernel_size=(3, 3), padding='same')(x)
+    keras_model = keras.models.Model(data, x)
+    verify_keras_frontend(keras_model)
+
+
 if __name__ == '__main__':
     test_forward_softrelu()
     test_forward_leaky_relu()
@@ -233,6 +250,7 @@ if __name__ == '__main__':
     test_forward_vgg16()
     test_forward_xception()
     test_forward_resnet50()
+    test_forward_unet()
 
     test_forward_shape_inference()
 

--- a/tests/python/frontend/keras/test_forward.py
+++ b/tests/python/frontend/keras/test_forward.py
@@ -15,7 +15,7 @@ set_session(tf.Session(config=config))
 
 def verify_keras_frontend(keras_model):
     in_shape = [dim.value if dim.value is not None else 1 for dim in keras_model.input_layers[0].input.shape]
-    out_shape = [dim.value if dim.value is not None else 1 for dim in keras_model.output_layers[0].output.shape]
+    out_shape = [dim.value if dim.value is not None else 1 for dim in keras_model.get_output_at(0).shape]
 
     def replace_nones(shape):
         return list([s if s else 128 for s in shape])


### PR DESCRIPTION
This PR increases the number of tests for the Keras frontend and makes the convolution, pooling and upsampling tests exhaustive (i.e. it tests a wider range of different input size, kernel and stride parameters). It also adds a test for forward shape inference, which does not currently work.

The exhaustive tests reveal some consistent failure cases in the convolution and pooling implementation. In particular, when using the LLVM backend, I get a consistent failure for Conv2D and SeparableConv2D when using input size 15x15, with kernel size 1x1 and stride 3x3. Similar failures can also be observed in the implementation of MaxPooling2D.

Open questions:
1. Is the goal to match the Keras/Tensorflow output in 100% of the cases (shape * kernel * stride) or is it ok if only the most common layouts are supported?
2. Is it allowed to have print statements inside the testing code? It is quite hard to identify the failing case otherwise.

This PR (or a similar PR) should be merged before #308 