### PR TITLE
Update frontend for keras 2.1.3 compatibility

### DIFF
--- a/python/nnvm/frontend/keras.py
+++ b/python/nnvm/frontend/keras.py
@@ -484,9 +484,14 @@ def from_keras(model):
             symtab.get_var(keras_layer.name, must_contain=False)
         else:
             predecessors = []
-            print(keras_layer.name)
             inbound_nodes = keras_layer.inbound_nodes if hasattr(keras_layer, 'inbound_nodes') \
-                        else keras_layer._inbound_nodes
+                        else keras_layer._inbound_nodes if hasattr(keras_layer, '_inbound_nodes') \
+                        else None
+
+            if inbound_nodes is None:
+                raise TypeError("Unknown layer type or unsupported Keras version : {}"
+                                .format(keras_layer))
+
             for node in inbound_nodes:
                 for pred in node.inbound_layers:
                     predecessors.append(pred.name)

--- a/python/nnvm/frontend/keras.py
+++ b/python/nnvm/frontend/keras.py
@@ -349,7 +349,14 @@ def _convert_concat(insym, keras_layer, _):
 
 
 def _convert_reshape(insym, keras_layer, _):
-    return _sym.reshape(insym, keras_layer.shape)
+    shape = keras_layer.shape if hasattr(keras_layer, 'shape') else \
+                keras_layer.target_shape if hasattr(keras_layer, 'target_shape') else\
+                None
+
+    if shape is None:
+        raise TypeError("No shape attribute in reshape layer: {}".format(keras_layer))
+
+    return _sym.reshape(insym, shape=shape)
 
 
 def _default_skip(insym, keras_layer, _): # pylint: disable=unused-argument
@@ -477,7 +484,10 @@ def from_keras(model):
             symtab.get_var(keras_layer.name, must_contain=False)
         else:
             predecessors = []
-            for node in keras_layer.inbound_nodes:
+            print(keras_layer.name)
+            inbound_nodes = keras_layer.inbound_nodes if hasattr(keras_layer, 'inbound_nodes') \
+                        else keras_layer._inbound_nodes
+            for node in inbound_nodes:
                 for pred in node.inbound_layers:
                     predecessors.append(pred.name)
             if len(predecessors) == 1:


### PR DESCRIPTION
Keras keeps obsessively renaming properties every second release. Keras 2.1.3 renames `layer.inbound_nodes` to `layer._inbound_nodes`.

This PR fixes the crashes that occur when converting a Keras 2.1.3 model to NNVM. It is backwards compatible with previous Keras versions so it should not break anything else.