### PR TITLE
Fix BinaryBroadcastShape() when layout is not NCHW

### DIFF
--- a/include/nnvm/top/tensor.h
+++ b/include/nnvm/top/tensor.h
@@ -9,6 +9,7 @@
 #include <dmlc/base.h>
 #include <dmlc/parameter.h>
 #include <nnvm/tuple.h>
+#include <nnvm/top/nn.h>
 
 namespace nnvm {
 namespace top {
@@ -127,6 +128,22 @@ struct BroadcastToParam : public dmlc::Parameter<BroadcastToParam> {
       .describe("The shape of the desired array."
                 " We can set the dim to zero if it's same as the original."
                 " E.g `A = broadcast_to(B, shape=(10, 0, 0))` ");
+  }
+};
+
+struct BinaryBroadcastParam: public dmlc::Parameter<BinaryBroadcastParam> {
+  int layout;
+
+  DMLC_DECLARE_PARAMETER(BinaryBroadcastParam) {
+    DMLC_DECLARE_FIELD(layout)
+      .add_enum("NCHW", kNCHW)
+      .add_enum("NHWC", kNHWC)
+      .add_enum("CHWN", kCHWN)
+      .set_default(kNCHW)
+      .describe("Dimension ordering of data. Can be 'NCHW', 'NHWC', etc."
+                "'N', 'C', 'H', 'W' stands for batch, channel, height, and width"
+                "dimensions respectively. Convolution is applied on the 'H' and"
+                "'W' dimensions.");
   }
 };
 


### PR DESCRIPTION
For BatchNorm ops of an inference graph, SimplifyInference (simplify_inference.cc) will replace them with broadcast_mul/broadcast_add stuff. Therefore, the layout information should pass along this graph rewrite pass to ensure correct shape inference of BinaryBroadcastShape.
This is only the initial tentative fix to this issue. Comments are greatly appreciated.