### PR TITLE
[Compilation Warning Fix]Enum constant in boolean context

### DIFF
--- a/src/compiler/fold_scale_axis.cc
+++ b/src/compiler/fold_scale_axis.cc
@@ -152,7 +152,7 @@ Graph FoldScaleAxis(Graph src) {
     bwd_chain[nid].kind = kind;
     if (kind == kNone) continue;
     CHECK_GE(in_axis.size(), 1U);
-    CHECK(kind == kPassTroughFirst || kMulConsumer);
+    CHECK(kind == kPassTroughFirst || kind == kMulConsumer);
     // propagate back.
     bool can_prop = true;
     for (size_t i = 0; i < in_axis.size(); ++i) {


### PR DESCRIPTION
The below compilation warning is fixed.

In file included from /mnt/D_DRIVE/work/nnvm_8_feb/dmlc-core/include/dmlc/any.h:16:0,
                 from include/nnvm/./base.h:11,
                 from include/nnvm/graph.h:15,
                 from src/compiler/fold_scale_axis.cc:6:
src/compiler/fold_scale_axis.cc: In function ‘nnvm::Graph nnvm::compiler::FoldScaleAxis(nnvm::Graph)’:
src/compiler/fold_scale_axis.cc:155:39: warning: enum constant in boolean context [-Wint-in-bool-context]
     CHECK(kind == kPassTroughFirst || kMulConsumer);
                                       ^
/mnt/D_DRIVE/work/nnvm_8_feb/dmlc-core/include/dmlc/./logging.h:110:9: note: in definition of macro ‘CHECK’
   if (!(x))