### PR TITLE
fix mxnet model import

### DIFF
--- a/python/nnvm/frontend/mxnet.py
+++ b/python/nnvm/frontend/mxnet.py
@@ -312,7 +312,7 @@ def _from_mxnet_impl(symbol, graph):
     attr = symbol.list_attr()
     # op_name = symbol.attr('op_name')
     childs = symbol.get_children()
-    if childs:
+    if childs is not None:
         op_name = symbol.attr('op_name')
         childs = [_from_mxnet_impl(childs[i], graph) for i in range(len(childs.list_outputs()))]
         childs = [x for y in childs for x in _as_list(y)]  # expand group symbol


### PR DESCRIPTION
In latest mxnet, it raises error

```
 File "/home/ubuntu/.local/lib/python2.7/site-packages/nnvm-0.8.0-py2.7.egg/nnvm/frontend/mxnet.py", line 382, in from_mxnet
    sym = _from_mxnet_impl(symbol, {})
  File "/home/ubuntu/.local/lib/python2.7/site-packages/nnvm-0.8.0-py2.7.egg/nnvm/frontend/mxnet.py", line 343, in _from_mxnet_impl
    if childs:
  File "/usr/local/lib/python2.7/dist-packages/mxnet/symbol/symbol.py", line 107, in __bool__
    raise NotImplementedForSymbol(self.__bool__, 'bool')
mxnet.base.NotImplementedForSymbol: Function __bool__ (namely operator "bool") is not implemented for Symbol and only available in NDArray.
```

https://github.com/apache/incubator-mxnet/blob/6c3e1a4ba44ccdceabfd28b933303f4f1a1a0337/python/mxnet/symbol/symbol.py#L107