### PR TITLE
add PATH to dll_path on windows

### DIFF
--- a/python/nnvm/libinfo.py
+++ b/python/nnvm/libinfo.py
@@ -37,6 +37,8 @@ def find_lib_path():
         dll_path.extend([p.strip() for p in os.environ['LD_LIBRARY_PATH'].split(":")])
     elif sys.platform.startswith('darwin') and os.environ.get('DYLD_LIBRARY_PATH', None):
         dll_path.extend([p.strip() for p in os.environ['DYLD_LIBRARY_PATH'].split(":")])
+    elif sys.platform.startswith('win32') and os.environ.get('PATH', None):
+        dll_path.extend([p.strip() for p in os.environ['PATH'].split(";")])
 
     if sys.platform.startswith('win32'):
         vs_configuration = 'Release'


### PR DESCRIPTION
On Windows, usually we search dll from PATH (similar as LD_LIBRARY_PATH on Linux), add this option to make it more flexible when use nnvm on Windows. (right now it depends on the 'build' folder name)