### PR TITLE
add use_mt option, default to use md instead of md

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,18 +31,21 @@ add_definitions(-DNNVM_EXPORTS)
 # Build a shared lib (libnnvm.so) by default
 option(BUILD_SHARED_NNVM "Build a shared nnvm lib" ON)
 option(BUILD_STATIC_NNVM "Build a static nnvm lib" OFF)
+option(USE_MSVC_MT "Build with MT" OFF)
 
 # compile
 if(MSVC)
   add_definitions(-DDMLC_USE_CXX11)
   add_definitions(-DDMLC_STRICT_CXX11)
-  foreach(flag_var
+  if (USE_MSVC_MT)
+    foreach(flag_var
         CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
         CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
-    if(${flag_var} MATCHES "/MD")
-      string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-    endif(${flag_var} MATCHES "/MD")
-  endforeach(flag_var)
+      if(${flag_var} MATCHES "/MD")
+	    string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+      endif(${flag_var} MATCHES "/MD")
+    endforeach(flag_var)
+  endif()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
   find_library(TVM_LIB tvm
 			   HINTS ${CMAKE_CURRENT_SOURCE_DIR}/../tvm/build/Release


### PR DESCRIPTION
This pr is for fixing issue #480， I go with use /Md option now as it is more easier.
add the use_mt cmake option, which similar to what tvm did.