### PR TITLE
Add count_include_pad support

### DIFF
--- a/include/nnvm/top/nn.h
+++ b/include/nnvm/top/nn.h
@@ -218,14 +218,14 @@ struct Conv2DTransposeParam : public dmlc::Parameter<Conv2DTransposeParam> {
 };
 
 
-struct Pool2DParam : public dmlc::Parameter<Pool2DParam> {
+struct MaxPool2DParam : public dmlc::Parameter<MaxPool2DParam> {
   TShape pool_size;
   TShape strides;
   TShape padding;
   std::string layout;
   bool ceil_mode;
 
-  DMLC_DECLARE_PARAMETER(Pool2DParam) {
+  DMLC_DECLARE_PARAMETER(MaxPool2DParam) {
     DMLC_DECLARE_FIELD(pool_size)
       .describe("Size of the pooling windows..");
     DMLC_DECLARE_FIELD(strides).set_default(TShape({1, 1}))
@@ -240,6 +240,35 @@ struct Pool2DParam : public dmlc::Parameter<Pool2DParam> {
                 "'W' dimensions.");
     DMLC_DECLARE_FIELD(ceil_mode).set_default(false)
       .describe("When true, will use ceil instead of floor to compute the output shape.");
+  }
+};
+
+
+struct AvgPool2DParam : public dmlc::Parameter<AvgPool2DParam> {
+  TShape pool_size;
+  TShape strides;
+  TShape padding;
+  std::string layout;
+  bool ceil_mode;
+  bool count_include_pad;
+
+  DMLC_DECLARE_PARAMETER(AvgPool2DParam) {
+    DMLC_DECLARE_FIELD(pool_size)
+      .describe("Size of the pooling windows..");
+    DMLC_DECLARE_FIELD(strides).set_default(TShape({1, 1}))
+      .describe("Specifies the strides of the convolution.");
+    DMLC_DECLARE_FIELD(padding).set_default(TShape({0, 0}))
+      .describe("If padding is non-zero, then the input is implicitly zero-padded"
+                "on both sides for padding number of points");
+    DMLC_DECLARE_FIELD(layout).set_default("NCHW")
+      .describe("Dimension ordering of data and weight. Can be 'NCHW', 'NHWC', etc."
+                "'N', 'C', 'H', 'W' stands for batch, channel, height, and width"
+                "dimensions respectively. Convolution is applied on the 'H' and"
+                "'W' dimensions.");
+    DMLC_DECLARE_FIELD(ceil_mode).set_default(false)
+      .describe("When true, will use ceil instead of floor to compute the output shape.");
+    DMLC_DECLARE_FIELD(count_include_pad).set_default(false)
+      .describe("When true, will include padding to compute the average");
   }
 };
 

--- a/src/compiler/fold_scale_axis.cc
+++ b/src/compiler/fold_scale_axis.cc
@@ -354,28 +354,28 @@ NNVM_REGISTER_OP(leaky_relu)
 .set_attr<FScaleAxisForward>("FScaleAxisForward", ReluScaleAxisForward);
 
 // property registration.
+template <typename T>
 bool Pool2DBackward(
     const NodeAttrs& attrs,
     const std::vector<TShape>& in_shape,
     const std::vector<TShape>& out_shape,
     const FoldChainInfo& out_info,
     std::vector<FoldChainInfo>* in_axis) {
-  using top::Pool2DParam;
-  const Pool2DParam& param = nnvm::get<Pool2DParam>(attrs.parsed);
+  const T& param = nnvm::get<T>(attrs.parsed);
   if (out_info.axis == 1 && param.layout == "NCHW") {
     (*in_axis)[0] = out_info;
   }
   return false;
 }
 
+template <typename T>
 bool Pool2DForward(
     const NodeAttrs& attrs,
     const std::vector<TShape>& in_shape,
     const std::vector<TShape>& out_shape,
     std::vector<FoldChainInfo>* in_info,
     FoldChainInfo* out_info) {
-  using top::Pool2DParam;
-  const Pool2DParam& param = nnvm::get<Pool2DParam>(attrs.parsed);
+  const T& param = nnvm::get<T>(attrs.parsed);
   if ((*in_info)[0].axis == 1 && param.layout == "NCHW") {
     *out_info = (*in_info)[0];
   }
@@ -383,16 +383,16 @@ bool Pool2DForward(
 }
 
 NNVM_REGISTER_OP(max_pool2d)
-.set_attr<FScaleAxisBackward>("FScaleAxisBackward", Pool2DBackward);
+.set_attr<FScaleAxisBackward>("FScaleAxisBackward", Pool2DBackward<top::MaxPool2DParam>);
 
 NNVM_REGISTER_OP(avg_pool2d)
-.set_attr<FScaleAxisBackward>("FScaleAxisBackward", Pool2DBackward);
+.set_attr<FScaleAxisBackward>("FScaleAxisBackward", Pool2DBackward<top::AvgPool2DParam>);
 
 NNVM_REGISTER_OP(max_pool2d)
-.set_attr<FScaleAxisForward>("FScaleAxisForward", Pool2DForward);
+.set_attr<FScaleAxisForward>("FScaleAxisForward", Pool2DForward<top::MaxPool2DParam>);
 
 NNVM_REGISTER_OP(avg_pool2d)
-.set_attr<FScaleAxisForward>("FScaleAxisForward", Pool2DForward);
+.set_attr<FScaleAxisForward>("FScaleAxisForward", Pool2DForward<top::AvgPool2DParam>);
 
 
 


### PR DESCRIPTION
This PR adds count_include_pad support to `avg_pool` and update tvm
Related: dmlc/tvm#1144