### PR TITLE
   Increase depfiles lookup.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,3 +104,4 @@ clean:
 -include build/*.d
 -include build/*/*.d
 -include build/*/*/*.d
+-include build/*/*/*/*.d


### PR DESCRIPTION
Increase depfiles lookup.
           Not able link build/src/top/tensor/*.d.
           Hence don't compile nnvm for a change in tvm/topi headers.